### PR TITLE
fix error: jax_array config option is removed in jax v0.4.14

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This project is distributed in [PyPI](https://pypi.org/project/jaxrenderer), and
 pip install jaxrenderer
 ```
 
-The minimum Python version is `3.8`, and the minimum JAX version is `0.4.0`. You may need to install `jaxlib` separately if you are using GPU or TPU; by default, the CPU version of jaxlib is installed. Please refer to [JAX's installation guide](https://github.com/google/jax#installation) for more details.
+The minimum Python version is `3.8`, and the minimum JAX version is `0.4.14`. You may need to install `jaxlib` separately if you are using GPU or TPU; by default, the CPU version of jaxlib is installed. Please refer to [JAX's installation guide](https://github.com/google/jax#installation) for more details.
 
 ## Usage
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,9 +33,9 @@ include = [
 
 [tool.poetry.dependencies]
 python = "^3.8"
-jax = "^0.4.0"
+jax = "^0.4.14"
 numpy = "^1.22.0"
-jaxlib = {version = "^0.4.0", source = "jax"}
+jaxlib = {version = "^0.4.14", source = "jax"}
 jaxtyping = [
     {version = ">=0.2.13,<0.2.20", python = ">=3.8,<3.9"},
     {version = "^0.2.19", python = "^3.9"}

--- a/renderer/pipeline.py
+++ b/renderer/pipeline.py
@@ -40,7 +40,6 @@ from .types import (
     ZBuffer,
 )
 
-jax.config.update("jax_array", True)  # pyright: ignore[reportUnknownMemberType]
 
 RowIndices = Integer[Array, "row_batches row_batch_size"]
 """Indices of the rows in the buffers to be processed in this batch."""

--- a/renderer/shader.py
+++ b/renderer/shader.py
@@ -28,7 +28,6 @@ from .types import (
     Vec4f,
 )
 
-jax.config.update("jax_array", True)  # pyright: ignore[reportUnknownMemberType]
 
 ID: TypeAlias = IntV
 

--- a/renderer/shaders/depth.py
+++ b/renderer/shaders/depth.py
@@ -14,7 +14,6 @@ from ..geometry import Camera, to_homogeneous
 from ..shader import ID, PerVertex, Shader
 from ..types import Vec4f
 
-jax.config.update("jax_array", True)  # pyright: ignore[reportUnknownMemberType]
 
 
 class DepthExtraInput(NamedTuple):

--- a/renderer/shaders/gouraud.py
+++ b/renderer/shaders/gouraud.py
@@ -15,7 +15,6 @@ from ..geometry import Camera, normalise, to_homogeneous
 from ..shader import ID, PerFragment, PerVertex, Shader
 from ..types import BoolV, Colour, FloatV, LightSource, Vec2f, Vec3f, Vec4f
 
-jax.config.update("jax_array", True)  # pyright: ignore[reportUnknownMemberType]
 
 
 class GouraudExtraInput(NamedTuple):

--- a/renderer/shaders/gouraud_texture.py
+++ b/renderer/shaders/gouraud_texture.py
@@ -16,7 +16,6 @@ from ..geometry import Camera, normalise, to_homogeneous
 from ..shader import ID, MixerOutput, PerFragment, PerVertex, Shader
 from ..types import BoolV, Colour, FloatV, LightSource, Texture, Vec2f, Vec3f, Vec4f
 
-jax.config.update("jax_array", True)  # pyright: ignore[reportUnknownMemberType]
 
 
 class GouraudTextureExtraInput(NamedTuple):

--- a/renderer/shaders/phong.py
+++ b/renderer/shaders/phong.py
@@ -16,7 +16,6 @@ from ..geometry import Camera, normalise, to_homogeneous
 from ..shader import ID, MixerOutput, PerFragment, PerVertex, Shader
 from ..types import BoolV, Colour, LightSource, Texture, Vec2f, Vec3f, Vec4f
 
-jax.config.update("jax_array", True)  # pyright: ignore[reportUnknownMemberType]
 
 
 class PhongTextureExtraInput(NamedTuple):

--- a/renderer/shaders/phong_darboux.py
+++ b/renderer/shaders/phong_darboux.py
@@ -35,7 +35,6 @@ from ..types import (
     Vec4f,
 )
 
-jax.config.update("jax_array", True)  # pyright: ignore[reportUnknownMemberType]
 
 Triangle3f: TypeAlias = Float[Array, "3 3"]
 Triangle2f: TypeAlias = Float[Array, "3 2"]

--- a/renderer/shaders/phong_reflection.py
+++ b/renderer/shaders/phong_reflection.py
@@ -29,7 +29,6 @@ from ..types import (
     Vec4f,
 )
 
-jax.config.update("jax_array", True)  # pyright: ignore[reportUnknownMemberType]
 
 
 class PhongReflectionTextureExtraInput(NamedTuple):

--- a/renderer/shaders/phong_reflection_shadow.py
+++ b/renderer/shaders/phong_reflection_shadow.py
@@ -30,7 +30,6 @@ from ..types import (
     Vec4f,
 )
 
-jax.config.update("jax_array", True)  # pyright: ignore[reportUnknownMemberType]
 
 
 class PhongReflectionShadowTextureExtraInput(NamedTuple):

--- a/renderer/types.py
+++ b/renderer/types.py
@@ -40,7 +40,6 @@ __all__ = [
     "Buffers",
 ]
 
-jax.config.update("jax_array", True)  # pyright: ignore[reportUnknownMemberType]
 
 BoolV: TypeAlias = Bool[Array, ""]
 """JAX Array with single bool value.""" ""

--- a/test_resources/utils.py
+++ b/test_resources/utils.py
@@ -11,7 +11,6 @@ import numpy as np
 from renderer import Tuple, TypeAlias
 from renderer.types import FaceIndices, Normals, Texture, UVCoordinates, Vertices
 
-jax.config.update("jax_array", True)  # pyright: ignore[reportUnknownMemberType]
 
 T2f: TypeAlias = Tuple[float, float]
 T3f: TypeAlias = Tuple[float, float, float]


### PR DESCRIPTION
`jax_array ` config option has been removed since jax commit [59509dc](https://github.com/google/jax/commit/59509dc2b38cad37b211ad5fc65568cb7fcc7439).