### PR TITLE
fix error: jax_array config option is removed in jax v0.4.14

### DIFF
--- a/renderer/pipeline.py
+++ b/renderer/pipeline.py
@@ -40,7 +40,8 @@ from .types import (
     ZBuffer,
 )
 
-jax.config.update("jax_array", True)  # pyright: ignore[reportUnknownMemberType]
+if "jax_array" in dir(jax.config):
+    jax.config.update("jax_array", True)  # pyright: ignore[reportUnknownMemberType]
 
 RowIndices = Integer[Array, "row_batches row_batch_size"]
 """Indices of the rows in the buffers to be processed in this batch."""

--- a/renderer/pipeline.py
+++ b/renderer/pipeline.py
@@ -40,8 +40,6 @@ from .types import (
     ZBuffer,
 )
 
-jax.config.update("jax_array", True)  # pyright: ignore[reportUnknownMemberType]
-
 RowIndices = Integer[Array, "row_batches row_batch_size"]
 """Indices of the rows in the buffers to be processed in this batch."""
 

--- a/renderer/pipeline.py
+++ b/renderer/pipeline.py
@@ -40,6 +40,8 @@ from .types import (
     ZBuffer,
 )
 
+jax.config.update("jax_array", True)  # pyright: ignore[reportUnknownMemberType]
+
 RowIndices = Integer[Array, "row_batches row_batch_size"]
 """Indices of the rows in the buffers to be processed in this batch."""
 

--- a/renderer/pipeline.py
+++ b/renderer/pipeline.py
@@ -40,7 +40,7 @@ from .types import (
     ZBuffer,
 )
 
-if "jax_array" in dir(jax.config):
+if hasattr(jax.config, "jax_array"):
     jax.config.update("jax_array", True)  # pyright: ignore[reportUnknownMemberType]
 
 RowIndices = Integer[Array, "row_batches row_batch_size"]

--- a/renderer/shader.py
+++ b/renderer/shader.py
@@ -28,6 +28,8 @@ from .types import (
     Vec4f,
 )
 
+jax.config.update("jax_array", True)  # pyright: ignore[reportUnknownMemberType]
+
 ID: TypeAlias = IntV
 
 ShaderExtraInputT = TypeVar(

--- a/renderer/shader.py
+++ b/renderer/shader.py
@@ -28,7 +28,7 @@ from .types import (
     Vec4f,
 )
 
-if "jax_array" in dir(jax.config):
+if hasattr(jax.config, "jax_array"):
     jax.config.update("jax_array", True)  # pyright: ignore[reportUnknownMemberType]
 
 ID: TypeAlias = IntV

--- a/renderer/shader.py
+++ b/renderer/shader.py
@@ -28,8 +28,6 @@ from .types import (
     Vec4f,
 )
 
-jax.config.update("jax_array", True)  # pyright: ignore[reportUnknownMemberType]
-
 ID: TypeAlias = IntV
 
 ShaderExtraInputT = TypeVar(

--- a/renderer/shader.py
+++ b/renderer/shader.py
@@ -28,7 +28,8 @@ from .types import (
     Vec4f,
 )
 
-jax.config.update("jax_array", True)  # pyright: ignore[reportUnknownMemberType]
+if "jax_array" in dir(jax.config):
+    jax.config.update("jax_array", True)  # pyright: ignore[reportUnknownMemberType]
 
 ID: TypeAlias = IntV
 

--- a/renderer/shaders/depth.py
+++ b/renderer/shaders/depth.py
@@ -14,8 +14,6 @@ from ..geometry import Camera, to_homogeneous
 from ..shader import ID, PerVertex, Shader
 from ..types import Vec4f
 
-jax.config.update("jax_array", True)  # pyright: ignore[reportUnknownMemberType]
-
 
 class DepthExtraInput(NamedTuple):
     """Extra input for Depth Shader.

--- a/renderer/shaders/depth.py
+++ b/renderer/shaders/depth.py
@@ -14,7 +14,7 @@ from ..geometry import Camera, to_homogeneous
 from ..shader import ID, PerVertex, Shader
 from ..types import Vec4f
 
-if "jax_array" in dir(jax.config):
+if hasattr(jax.config, "jax_array"):
     jax.config.update("jax_array", True)  # pyright: ignore[reportUnknownMemberType]
 
 

--- a/renderer/shaders/depth.py
+++ b/renderer/shaders/depth.py
@@ -14,7 +14,8 @@ from ..geometry import Camera, to_homogeneous
 from ..shader import ID, PerVertex, Shader
 from ..types import Vec4f
 
-jax.config.update("jax_array", True)  # pyright: ignore[reportUnknownMemberType]
+if "jax_array" in dir(jax.config):
+    jax.config.update("jax_array", True)  # pyright: ignore[reportUnknownMemberType]
 
 
 class DepthExtraInput(NamedTuple):

--- a/renderer/shaders/depth.py
+++ b/renderer/shaders/depth.py
@@ -14,6 +14,8 @@ from ..geometry import Camera, to_homogeneous
 from ..shader import ID, PerVertex, Shader
 from ..types import Vec4f
 
+jax.config.update("jax_array", True)  # pyright: ignore[reportUnknownMemberType]
+
 
 class DepthExtraInput(NamedTuple):
     """Extra input for Depth Shader.

--- a/renderer/shaders/gouraud.py
+++ b/renderer/shaders/gouraud.py
@@ -15,7 +15,8 @@ from ..geometry import Camera, normalise, to_homogeneous
 from ..shader import ID, PerFragment, PerVertex, Shader
 from ..types import BoolV, Colour, FloatV, LightSource, Vec2f, Vec3f, Vec4f
 
-jax.config.update("jax_array", True)  # pyright: ignore[reportUnknownMemberType]
+if "jax_array" in dir(jax.config):
+    jax.config.update("jax_array", True)  # pyright: ignore[reportUnknownMemberType]
 
 
 class GouraudExtraInput(NamedTuple):

--- a/renderer/shaders/gouraud.py
+++ b/renderer/shaders/gouraud.py
@@ -15,6 +15,8 @@ from ..geometry import Camera, normalise, to_homogeneous
 from ..shader import ID, PerFragment, PerVertex, Shader
 from ..types import BoolV, Colour, FloatV, LightSource, Vec2f, Vec3f, Vec4f
 
+jax.config.update("jax_array", True)  # pyright: ignore[reportUnknownMemberType]
+
 
 class GouraudExtraInput(NamedTuple):
     """Extra input for Gouraud Shader.

--- a/renderer/shaders/gouraud.py
+++ b/renderer/shaders/gouraud.py
@@ -15,8 +15,6 @@ from ..geometry import Camera, normalise, to_homogeneous
 from ..shader import ID, PerFragment, PerVertex, Shader
 from ..types import BoolV, Colour, FloatV, LightSource, Vec2f, Vec3f, Vec4f
 
-jax.config.update("jax_array", True)  # pyright: ignore[reportUnknownMemberType]
-
 
 class GouraudExtraInput(NamedTuple):
     """Extra input for Gouraud Shader.

--- a/renderer/shaders/gouraud.py
+++ b/renderer/shaders/gouraud.py
@@ -15,7 +15,7 @@ from ..geometry import Camera, normalise, to_homogeneous
 from ..shader import ID, PerFragment, PerVertex, Shader
 from ..types import BoolV, Colour, FloatV, LightSource, Vec2f, Vec3f, Vec4f
 
-if "jax_array" in dir(jax.config):
+if hasattr(jax.config, "jax_array"):
     jax.config.update("jax_array", True)  # pyright: ignore[reportUnknownMemberType]
 
 

--- a/renderer/shaders/gouraud_texture.py
+++ b/renderer/shaders/gouraud_texture.py
@@ -16,8 +16,6 @@ from ..geometry import Camera, normalise, to_homogeneous
 from ..shader import ID, MixerOutput, PerFragment, PerVertex, Shader
 from ..types import BoolV, Colour, FloatV, LightSource, Texture, Vec2f, Vec3f, Vec4f
 
-jax.config.update("jax_array", True)  # pyright: ignore[reportUnknownMemberType]
-
 
 class GouraudTextureExtraInput(NamedTuple):
     """Extra input for Gouraud Shader.

--- a/renderer/shaders/gouraud_texture.py
+++ b/renderer/shaders/gouraud_texture.py
@@ -16,7 +16,7 @@ from ..geometry import Camera, normalise, to_homogeneous
 from ..shader import ID, MixerOutput, PerFragment, PerVertex, Shader
 from ..types import BoolV, Colour, FloatV, LightSource, Texture, Vec2f, Vec3f, Vec4f
 
-if "jax_array" in dir(jax.config):
+if hasattr(jax.config, "jax_array"):
     jax.config.update("jax_array", True)  # pyright: ignore[reportUnknownMemberType]
 
 

--- a/renderer/shaders/gouraud_texture.py
+++ b/renderer/shaders/gouraud_texture.py
@@ -16,6 +16,8 @@ from ..geometry import Camera, normalise, to_homogeneous
 from ..shader import ID, MixerOutput, PerFragment, PerVertex, Shader
 from ..types import BoolV, Colour, FloatV, LightSource, Texture, Vec2f, Vec3f, Vec4f
 
+jax.config.update("jax_array", True)  # pyright: ignore[reportUnknownMemberType]
+
 
 class GouraudTextureExtraInput(NamedTuple):
     """Extra input for Gouraud Shader.

--- a/renderer/shaders/gouraud_texture.py
+++ b/renderer/shaders/gouraud_texture.py
@@ -16,7 +16,8 @@ from ..geometry import Camera, normalise, to_homogeneous
 from ..shader import ID, MixerOutput, PerFragment, PerVertex, Shader
 from ..types import BoolV, Colour, FloatV, LightSource, Texture, Vec2f, Vec3f, Vec4f
 
-jax.config.update("jax_array", True)  # pyright: ignore[reportUnknownMemberType]
+if "jax_array" in dir(jax.config):
+    jax.config.update("jax_array", True)  # pyright: ignore[reportUnknownMemberType]
 
 
 class GouraudTextureExtraInput(NamedTuple):

--- a/renderer/shaders/phong.py
+++ b/renderer/shaders/phong.py
@@ -16,6 +16,8 @@ from ..geometry import Camera, normalise, to_homogeneous
 from ..shader import ID, MixerOutput, PerFragment, PerVertex, Shader
 from ..types import BoolV, Colour, LightSource, Texture, Vec2f, Vec3f, Vec4f
 
+jax.config.update("jax_array", True)  # pyright: ignore[reportUnknownMemberType]
+
 
 class PhongTextureExtraInput(NamedTuple):
     """Extra input for Phong Shader.

--- a/renderer/shaders/phong.py
+++ b/renderer/shaders/phong.py
@@ -16,8 +16,6 @@ from ..geometry import Camera, normalise, to_homogeneous
 from ..shader import ID, MixerOutput, PerFragment, PerVertex, Shader
 from ..types import BoolV, Colour, LightSource, Texture, Vec2f, Vec3f, Vec4f
 
-jax.config.update("jax_array", True)  # pyright: ignore[reportUnknownMemberType]
-
 
 class PhongTextureExtraInput(NamedTuple):
     """Extra input for Phong Shader.

--- a/renderer/shaders/phong.py
+++ b/renderer/shaders/phong.py
@@ -16,7 +16,7 @@ from ..geometry import Camera, normalise, to_homogeneous
 from ..shader import ID, MixerOutput, PerFragment, PerVertex, Shader
 from ..types import BoolV, Colour, LightSource, Texture, Vec2f, Vec3f, Vec4f
 
-if "jax_array" in dir(jax.config):
+if hasattr(jax.config, "jax_array"):
     jax.config.update("jax_array", True)  # pyright: ignore[reportUnknownMemberType]
 
 

--- a/renderer/shaders/phong.py
+++ b/renderer/shaders/phong.py
@@ -16,7 +16,8 @@ from ..geometry import Camera, normalise, to_homogeneous
 from ..shader import ID, MixerOutput, PerFragment, PerVertex, Shader
 from ..types import BoolV, Colour, LightSource, Texture, Vec2f, Vec3f, Vec4f
 
-jax.config.update("jax_array", True)  # pyright: ignore[reportUnknownMemberType]
+if "jax_array" in dir(jax.config):
+    jax.config.update("jax_array", True)  # pyright: ignore[reportUnknownMemberType]
 
 
 class PhongTextureExtraInput(NamedTuple):

--- a/renderer/shaders/phong_darboux.py
+++ b/renderer/shaders/phong_darboux.py
@@ -35,7 +35,8 @@ from ..types import (
     Vec4f,
 )
 
-jax.config.update("jax_array", True)  # pyright: ignore[reportUnknownMemberType]
+if "jax_array" in dir(jax.config):
+    jax.config.update("jax_array", True)  # pyright: ignore[reportUnknownMemberType]
 
 Triangle3f: TypeAlias = Float[Array, "3 3"]
 Triangle2f: TypeAlias = Float[Array, "3 2"]

--- a/renderer/shaders/phong_darboux.py
+++ b/renderer/shaders/phong_darboux.py
@@ -35,7 +35,7 @@ from ..types import (
     Vec4f,
 )
 
-if "jax_array" in dir(jax.config):
+if hasattr(jax.config, "jax_array"):
     jax.config.update("jax_array", True)  # pyright: ignore[reportUnknownMemberType]
 
 Triangle3f: TypeAlias = Float[Array, "3 3"]

--- a/renderer/shaders/phong_darboux.py
+++ b/renderer/shaders/phong_darboux.py
@@ -35,6 +35,8 @@ from ..types import (
     Vec4f,
 )
 
+jax.config.update("jax_array", True)  # pyright: ignore[reportUnknownMemberType]
+
 Triangle3f: TypeAlias = Float[Array, "3 3"]
 Triangle2f: TypeAlias = Float[Array, "3 2"]
 

--- a/renderer/shaders/phong_darboux.py
+++ b/renderer/shaders/phong_darboux.py
@@ -35,8 +35,6 @@ from ..types import (
     Vec4f,
 )
 
-jax.config.update("jax_array", True)  # pyright: ignore[reportUnknownMemberType]
-
 Triangle3f: TypeAlias = Float[Array, "3 3"]
 Triangle2f: TypeAlias = Float[Array, "3 2"]
 

--- a/renderer/shaders/phong_reflection.py
+++ b/renderer/shaders/phong_reflection.py
@@ -29,8 +29,6 @@ from ..types import (
     Vec4f,
 )
 
-jax.config.update("jax_array", True)  # pyright: ignore[reportUnknownMemberType]
-
 
 class PhongReflectionTextureExtraInput(NamedTuple):
     """Extra input for PhongReflection Shader.

--- a/renderer/shaders/phong_reflection.py
+++ b/renderer/shaders/phong_reflection.py
@@ -29,6 +29,8 @@ from ..types import (
     Vec4f,
 )
 
+jax.config.update("jax_array", True)  # pyright: ignore[reportUnknownMemberType]
+
 
 class PhongReflectionTextureExtraInput(NamedTuple):
     """Extra input for PhongReflection Shader.

--- a/renderer/shaders/phong_reflection.py
+++ b/renderer/shaders/phong_reflection.py
@@ -29,7 +29,7 @@ from ..types import (
     Vec4f,
 )
 
-if "jax_array" in dir(jax.config):
+if hasattr(jax.config, "jax_array"):
     jax.config.update("jax_array", True)  # pyright: ignore[reportUnknownMemberType]
 
 

--- a/renderer/shaders/phong_reflection.py
+++ b/renderer/shaders/phong_reflection.py
@@ -29,7 +29,8 @@ from ..types import (
     Vec4f,
 )
 
-jax.config.update("jax_array", True)  # pyright: ignore[reportUnknownMemberType]
+if "jax_array" in dir(jax.config):
+    jax.config.update("jax_array", True)  # pyright: ignore[reportUnknownMemberType]
 
 
 class PhongReflectionTextureExtraInput(NamedTuple):

--- a/renderer/shaders/phong_reflection_shadow.py
+++ b/renderer/shaders/phong_reflection_shadow.py
@@ -30,7 +30,8 @@ from ..types import (
     Vec4f,
 )
 
-jax.config.update("jax_array", True)  # pyright: ignore[reportUnknownMemberType]
+if "jax_array" in dir(jax.config):
+    jax.config.update("jax_array", True)  # pyright: ignore[reportUnknownMemberType]
 
 
 class PhongReflectionShadowTextureExtraInput(NamedTuple):

--- a/renderer/shaders/phong_reflection_shadow.py
+++ b/renderer/shaders/phong_reflection_shadow.py
@@ -30,7 +30,7 @@ from ..types import (
     Vec4f,
 )
 
-if "jax_array" in dir(jax.config):
+if hasattr(jax.config, "jax_array"):
     jax.config.update("jax_array", True)  # pyright: ignore[reportUnknownMemberType]
 
 

--- a/renderer/shaders/phong_reflection_shadow.py
+++ b/renderer/shaders/phong_reflection_shadow.py
@@ -30,6 +30,8 @@ from ..types import (
     Vec4f,
 )
 
+jax.config.update("jax_array", True)  # pyright: ignore[reportUnknownMemberType]
+
 
 class PhongReflectionShadowTextureExtraInput(NamedTuple):
     """Extra input for Phong Reflection with Shadow Shader.

--- a/renderer/shaders/phong_reflection_shadow.py
+++ b/renderer/shaders/phong_reflection_shadow.py
@@ -30,8 +30,6 @@ from ..types import (
     Vec4f,
 )
 
-jax.config.update("jax_array", True)  # pyright: ignore[reportUnknownMemberType]
-
 
 class PhongReflectionShadowTextureExtraInput(NamedTuple):
     """Extra input for Phong Reflection with Shadow Shader.

--- a/renderer/types.py
+++ b/renderer/types.py
@@ -40,6 +40,8 @@ __all__ = [
     "Buffers",
 ]
 
+jax.config.update("jax_array", True)  # pyright: ignore[reportUnknownMemberType]
+
 BoolV: TypeAlias = Bool[Array, ""]
 """JAX Array with single bool value.""" ""
 FloatV: TypeAlias = Float[Array, ""]

--- a/renderer/types.py
+++ b/renderer/types.py
@@ -40,7 +40,7 @@ __all__ = [
     "Buffers",
 ]
 
-if "jax_array" in dir(jax.config):
+if hasattr(jax.config, "jax_array"):
     jax.config.update("jax_array", True)  # pyright: ignore[reportUnknownMemberType]
 
 BoolV: TypeAlias = Bool[Array, ""]

--- a/renderer/types.py
+++ b/renderer/types.py
@@ -40,7 +40,8 @@ __all__ = [
     "Buffers",
 ]
 
-jax.config.update("jax_array", True)  # pyright: ignore[reportUnknownMemberType]
+if "jax_array" in dir(jax.config):
+    jax.config.update("jax_array", True)  # pyright: ignore[reportUnknownMemberType]
 
 BoolV: TypeAlias = Bool[Array, ""]
 """JAX Array with single bool value.""" ""

--- a/renderer/types.py
+++ b/renderer/types.py
@@ -40,8 +40,6 @@ __all__ = [
     "Buffers",
 ]
 
-jax.config.update("jax_array", True)  # pyright: ignore[reportUnknownMemberType]
-
 BoolV: TypeAlias = Bool[Array, ""]
 """JAX Array with single bool value.""" ""
 FloatV: TypeAlias = Float[Array, ""]

--- a/test_resources/utils.py
+++ b/test_resources/utils.py
@@ -11,7 +11,7 @@ import numpy as np
 from renderer import Tuple, TypeAlias
 from renderer.types import FaceIndices, Normals, Texture, UVCoordinates, Vertices
 
-if "jax_array" in dir(jax.config):
+if hasattr(jax.config, "jax_array"):
     jax.config.update("jax_array", True)  # pyright: ignore[reportUnknownMemberType]
 
 T2f: TypeAlias = Tuple[float, float]

--- a/test_resources/utils.py
+++ b/test_resources/utils.py
@@ -11,7 +11,8 @@ import numpy as np
 from renderer import Tuple, TypeAlias
 from renderer.types import FaceIndices, Normals, Texture, UVCoordinates, Vertices
 
-jax.config.update("jax_array", True)  # pyright: ignore[reportUnknownMemberType]
+if "jax_array" in dir(jax.config):
+    jax.config.update("jax_array", True)  # pyright: ignore[reportUnknownMemberType]
 
 T2f: TypeAlias = Tuple[float, float]
 T3f: TypeAlias = Tuple[float, float, float]


### PR DESCRIPTION
Reopened pull request, `jax_array`  config option has been removed since jax commit [59509dc](https://github.com/google/jax/commit/59509dc2b38cad37b211ad5fc65568cb7fcc7439).